### PR TITLE
Feature/diary page

### DIFF
--- a/diary.html
+++ b/diary.html
@@ -303,12 +303,13 @@
                     <option value="맑음">맑음</option>
                     <option value="흐림">흐림</option>
                     <option value="비">비</option>
-                    <option value="눈">우천 취소</option>
+                    <option value="우천 취소">우천 취소</option>
                 </select>
             </div>
             <div>
                 <label for="stadium">구장:</label>
                 <select id="stadium">
+                    <option value="NC 파크">NC 파크</option>
                     <option value="고척">고척 스카이돔</option>
                     <option value="랜더스 필드">랜더스 필드</option>
                     <option value="사직">사직 야구장</option>
@@ -404,6 +405,7 @@
         </div>
     </div>
 
+    <script src="diary.js"></script>
     <script>
         document.getElementById('addImageButton').addEventListener('click', function() {
             document.getElementById('fieldImage').click();

--- a/diary.html
+++ b/diary.html
@@ -323,8 +323,8 @@
 
         <div class="scoreboard">
             <div>
-                <img src="logos/kia.png" alt="홈 팀 로고" class="team-image">
-                <p>기아 타이거즈</p>
+                <img src="" alt="홈 팀 로고" class="team-image">
+                <p aria-label="Home Team Name">홈 팀</p>
             </div>
             <div>
                 <input type="number" min="0" max="99" placeholder="0" aria-label="Home Team Score">
@@ -332,8 +332,8 @@
                 <input type="number" min="0" max="99" placeholder="0" aria-label="Away Team Score">
             </div>
             <div>
-                <img src="logos/doosan.png" alt="어웨이 팀 로고" class="team-image">
-                <p>두산 베어스</p>
+                <img src="" alt="어웨이 팀 로고" class="team-image">
+                <p aria-label="Away Team Name">어웨이 팀</p>
             </div>
         </div>
 

--- a/diary.js
+++ b/diary.js
@@ -2,9 +2,15 @@ async function loadDiaryData() {
     // URL에서 날짜 가져오기
     const urlParams = new URLSearchParams(window.location.search);
     const selectedDate = urlParams.get('date');
+    const selectedGameContent = urlParams.get('game');
 
     if (!selectedDate) {
         window.location.href = "main.html?alert=날짜가 선택되지 않았습니다.";
+        return;
+    }
+
+    if (!selectedGameContent) {
+        window.location.href = "main.html?alert=경기가 선택되지 않았습니다.";
         return;
     }
 
@@ -26,6 +32,14 @@ async function loadDiaryData() {
 
         if (gamesOnSelectedDate.length === 0) {
             window.location.href = "main.html?alert=해당 날짜에 경기가 없습니다.";
+            return;
+        }
+
+        // URL에서 전달된 게임 내용과 일치하는 경기 찾기
+        const game = gamesOnSelectedDate.find(game => game.gameContent === selectedGameContent);
+
+        if (!game) {
+            window.location.href = "main.html?alert=선택한 경기를 찾을 수 없습니다.";
             return;
         }
 
@@ -79,9 +93,6 @@ async function loadDiaryData() {
             "대전": "이글스 파크",
             "고척": "고척"
         };
-
-        // 첫 번째 경기 정보로 필드 채우기: 추가 구현 예정
-        const game = gamesOnSelectedDate[0];
 
         // 경기 날짜 설정
         if (gameDateInput) gameDateInput.value = selectedDate.replace(/\./g, '-');

--- a/diary.js
+++ b/diary.js
@@ -1,0 +1,143 @@
+async function loadDiaryData() {
+    // URL에서 날짜 가져오기
+    const urlParams = new URLSearchParams(window.location.search);
+    const selectedDate = urlParams.get('date');
+
+    if (!selectedDate) {
+        alert("날짜가 선택되지 않았습니다.");
+        window.location.href = "main.html"; // main.html로 리다이렉트
+        return;
+    }
+
+    // 날짜 형식을 schedule.json에 맞게 변환
+    const dateObj = new Date(selectedDate.replace(/-/g, '/'));
+    const formattedDate = `${String(dateObj.getMonth() + 1).padStart(2, '0')}.${String(dateObj.getDate()).padStart(2, '0')}(${['일', '월', '화', '수', '목', '금', '토'][dateObj.getDay()]})`;
+
+    try {
+        // schedule.json 데이터 로드
+        const response = await fetch("schedule.json");
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const schedule = await response.json();
+
+        // 해당 날짜 데이터 필터링
+        const gamesOnSelectedDate = schedule.filter(game => game.day === formattedDate);
+
+        if (gamesOnSelectedDate.length === 0) {
+            alert("해당 날짜에 경기가 없습니다.");
+            window.location.href = "main.html";
+            return;
+        }
+
+        // html 요소 가져오기
+        const gameDateInput = document.getElementById("game-date");
+        const gameTimeInput = document.getElementById("game-time");
+        const stadiumSelect = document.getElementById("stadium");
+        const weatherSelect = document.getElementById("game-weather");
+        const homeTeamLogo = document.querySelector('.scoreboard img[alt="홈 팀 로고"]');
+        const awayTeamLogo = document.querySelector('.scoreboard img[alt="어웨이 팀 로고"]');
+        const homeTeamName = document.querySelector('.scoreboard p[aria-label="Home Team Name"]');
+        const awayTeamName = document.querySelector('.scoreboard p[aria-label="Away Team Name"]');
+        const homeTeamScore = document.querySelector(".scoreboard input[aria-label='Home Team Score']");
+        const awayTeamScore = document.querySelector(".scoreboard input[aria-label='Away Team Score']");
+
+        // 팀 로고 매핑 
+        const logoMapping = {
+            "키움": "logos/kiwoom.png",
+            "두산": "logos/doosan.png",
+            "LG": "logos/lg.png",
+            "KT": "logos/kt.png",
+            "SSG": "logos/ssg.png",
+            "KIA": "logos/kia.png",
+            "삼성": "logos/samsung.png",
+            "한화": "logos/hanhwa.png",
+            "NC": "logos/nc.png",
+            "롯데": "logos/lotte.png"
+        };
+        // 팀명 매핑
+        const nameMapping = {
+            "키움": "키움 히어로즈",
+            "두산": "두산 베어스",
+            "LG": "LG 트윈스",
+            "KT": "kt wiz",
+            "SSG": "SSG 랜더스",
+            "KIA": "KIA 타이거즈",
+            "삼성": "삼성 라이온즈",
+            "한화": "한화 이글스",
+            "NC": "NC 다이노스",
+            "롯데": "롯데 자이언츠",
+        };
+        // 구장 매핑
+        const stadiumMapping = {
+            "창원": "NC 파크",
+            "수원": "케이티 위즈 파크",
+            "잠실": "잠실",
+            "문학": "랜더스 필드",
+            "사직": "사직",
+            "대구": "삼성 라이온즈 파크",
+            "광주": "챔피언스 필드",
+            "대전": "이글스 파크",
+            "고척": "고척"
+        };
+
+        // 첫 번째 경기 정보로 필드 채우기: 추가 구현 예정
+        const game = gamesOnSelectedDate[0];
+
+        // 경기 날짜 설정
+        if (gameDateInput) gameDateInput.value = selectedDate;
+
+        // 경기 시간 설정
+        if (gameTimeInput) gameTimeInput.value = game.time;
+
+        // 날씨 설정 (rain 값에 따라 변경)
+        if (weatherSelect) {
+            if (game.rain === 1) {
+                weatherSelect.value = "우천 취소";
+            } else {
+                weatherSelect.value = "맑음"; // 기본값을 맑음으로 설정
+            }
+        }
+
+        // 구장 설정
+        if (stadiumSelect)  stadiumSelect.value = stadiumMapping[game.stadium];
+
+        // 경기 내용 파싱
+        const gameContentRegex = /([가-힣a-zA-Z]+)(\d*)vs(\d*)([가-힣a-zA-Z]+)/;
+        const match = gameContentRegex.exec(game.gameContent);
+
+        if (!match) {
+            console.error(`Invalid game content format: ${game.gameContent}`);
+            alert("경기 데이터를 분석할 수 없습니다.");
+            window.location.href = "main.html";
+            return;
+        }
+
+        const [, homeTeam, homeScore = "0", awayScore = "0", awayTeam] = match;
+
+        // 홈 팀 정보 설정
+        if (homeTeamLogo) {
+            homeTeamLogo.src = logoMapping[homeTeam] || "logos/default.png";
+            homeTeamLogo.alt = homeTeam;
+        }
+        if (homeTeamName) homeTeamName.textContent = nameMapping[homeTeam];
+        if (homeTeamScore) homeTeamScore.value = homeScore;
+
+        // 어웨이 팀 정보 설정
+        if (awayTeamLogo) {
+            awayTeamLogo.src = logoMapping[awayTeam] || "logos/default.png";
+            awayTeamLogo.alt = awayTeam;
+        }
+        if (awayTeamName) awayTeamName.textContent = nameMapping[awayTeam];
+        if (awayTeamScore) awayTeamScore.value = awayScore;
+
+    } catch (error) {
+        console.error("Error loading game data:", error);
+        alert("경기 데이터를 불러오는 데 실패했습니다.");
+        window.location.href = "main.html";
+    }
+}
+
+// 페이지 로드 시 실행
+loadDiaryData();

--- a/diary.js
+++ b/diary.js
@@ -4,13 +4,12 @@ async function loadDiaryData() {
     const selectedDate = urlParams.get('date');
 
     if (!selectedDate) {
-        alert("날짜가 선택되지 않았습니다.");
-        window.location.href = "main.html"; // main.html로 리다이렉트
+        window.location.href = "main.html?alert=날짜가 선택되지 않았습니다.";
         return;
     }
 
     // 날짜 형식을 schedule.json에 맞게 변환
-    const dateObj = new Date(selectedDate.replace(/-/g, '/'));
+    const dateObj = new Date(selectedDate);
     const formattedDate = `${String(dateObj.getMonth() + 1).padStart(2, '0')}.${String(dateObj.getDate()).padStart(2, '0')}(${['일', '월', '화', '수', '목', '금', '토'][dateObj.getDay()]})`;
 
     try {
@@ -26,8 +25,7 @@ async function loadDiaryData() {
         const gamesOnSelectedDate = schedule.filter(game => game.day === formattedDate);
 
         if (gamesOnSelectedDate.length === 0) {
-            alert("해당 날짜에 경기가 없습니다.");
-            window.location.href = "main.html";
+            window.location.href = "main.html?alert=해당 날짜에 경기가 없습니다.";
             return;
         }
 
@@ -86,7 +84,7 @@ async function loadDiaryData() {
         const game = gamesOnSelectedDate[0];
 
         // 경기 날짜 설정
-        if (gameDateInput) gameDateInput.value = selectedDate;
+        if (gameDateInput) gameDateInput.value = selectedDate.replace(/\./g, '-');
 
         // 경기 시간 설정
         if (gameTimeInput) gameTimeInput.value = game.time;
@@ -109,8 +107,7 @@ async function loadDiaryData() {
 
         if (!match) {
             console.error(`Invalid game content format: ${game.gameContent}`);
-            alert("경기 데이터를 분석할 수 없습니다.");
-            window.location.href = "main.html";
+            window.location.href = "main.html?alert=경기 데이터를 분석할 수 없습니다.";
             return;
         }
 
@@ -118,7 +115,7 @@ async function loadDiaryData() {
 
         // 홈 팀 정보 설정
         if (homeTeamLogo) {
-            homeTeamLogo.src = logoMapping[homeTeam] || "logos/default.png";
+            homeTeamLogo.src = logoMapping[homeTeam];
             homeTeamLogo.alt = homeTeam;
         }
         if (homeTeamName) homeTeamName.textContent = nameMapping[homeTeam];
@@ -126,7 +123,7 @@ async function loadDiaryData() {
 
         // 어웨이 팀 정보 설정
         if (awayTeamLogo) {
-            awayTeamLogo.src = logoMapping[awayTeam] || "logos/default.png";
+            awayTeamLogo.src = logoMapping[awayTeam];
             awayTeamLogo.alt = awayTeam;
         }
         if (awayTeamName) awayTeamName.textContent = nameMapping[awayTeam];
@@ -134,8 +131,8 @@ async function loadDiaryData() {
 
     } catch (error) {
         console.error("Error loading game data:", error);
-        alert("경기 데이터를 불러오는 데 실패했습니다.");
-        window.location.href = "main.html";
+        window.location.href = "main.html?alert=경기 데이터를 불러오는 데 실패했습니다.";
+        return;
     }
 }
 

--- a/main.html
+++ b/main.html
@@ -278,9 +278,9 @@
             dateDiv.textContent = day;
 
             // 클릭 이벤트
-            dateDiv.addEventListener("click", () => {
+            dateDiv.addEventListener("click", (event) => {
                 const formattedDate = `${year}.${(month + 1).toString().padStart(2, "0")}.${day.toString().padStart(2, "0")}`;
-                window.location.href = `diary.html?date=${formattedDate}`;
+                showGameOptions(formattedDate, event); // 마우스 위치를 함께 전달
             });
 
             if (

--- a/main.html
+++ b/main.html
@@ -276,6 +276,12 @@
             dateDiv.classList.add("calendar-day");
             dateDiv.textContent = day;
 
+            // 클릭 이벤트
+            dateDiv.addEventListener("click", () => {
+                const formattedDate = `${year}.${(month + 1).toString().padStart(2, "0")}.${day.toString().padStart(2, "0")}`;
+                window.location.href = `diary.html?date=${formattedDate}`;
+            });
+
             if (
                 day === new Date().getDate() &&
                 month === new Date().getMonth() &&

--- a/main.html
+++ b/main.html
@@ -223,6 +223,7 @@
     </div>
 </div>
 
+<script src="main.js"></script>
 <script>
     let currentDate = new Date();
 

--- a/main.js
+++ b/main.js
@@ -9,3 +9,14 @@ document.querySelectorAll('.calendar-day').forEach(day => {
         window.location.href = `diary.html?date=${fullDate}`;
     });
 });
+
+function checkForAlert() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const alertMessage = urlParams.get('alert'); // 'alert' 키 값 확인
+
+    if (alertMessage) {
+        alert(decodeURIComponent(alertMessage));
+        history.replaceState({}, document.title, window.location.pathname);
+    }
+}
+window.onload = checkForAlert;

--- a/main.js
+++ b/main.js
@@ -1,0 +1,11 @@
+document.querySelectorAll('.calendar-day').forEach(day => {
+    day.addEventListener('click', () => {
+        const selectedDate = day.textContent.trim(); // 날짜 값 추출
+        const year = currentDate.getFullYear();
+        const month = (currentDate.getMonth() + 1).toString().padStart(2, '0');
+        const fullDate = `${year}.${month}.${selectedDate.padStart(2, '0')}`; // yyyy.MM.dd 형식으로 변환
+
+        // `diary.html`로 이동하며 날짜 전달
+        window.location.href = `diary.html?date=${fullDate}`;
+    });
+});

--- a/main.js
+++ b/main.js
@@ -1,15 +1,3 @@
-document.querySelectorAll('.calendar-day').forEach(day => {
-    day.addEventListener('click', () => {
-        const selectedDate = day.textContent.trim(); // 날짜 값 추출
-        const year = currentDate.getFullYear();
-        const month = (currentDate.getMonth() + 1).toString().padStart(2, '0');
-        const fullDate = `${year}.${month}.${selectedDate.padStart(2, '0')}`; // yyyy.MM.dd 형식으로 변환
-
-        // `diary.html`로 이동하며 날짜 전달
-        window.location.href = `diary.html?date=${fullDate}`;
-    });
-});
-
 function checkForAlert() {
     const urlParams = new URLSearchParams(window.location.search);
     const alertMessage = urlParams.get('alert'); // 'alert' 키 값 확인
@@ -20,3 +8,89 @@ function checkForAlert() {
     }
 }
 window.onload = checkForAlert;
+
+// 특정 날짜의 경기를 select로 표시
+async function showGameOptions(date, event) {
+    try {
+        // schedule.json 데이터 로드
+        const response = await fetch("schedule.json");
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const schedule = await response.json();
+
+        // 날짜를 "09.19(목)" 형식으로 변환
+        const dateObj = new Date(date);
+        const formattedDate = `${String(dateObj.getMonth() + 1).padStart(2, '0')}.${String(dateObj.getDate()).padStart(2, '0')}(${['일', '월', '화', '수', '목', '금', '토'][dateObj.getDay()]})`;
+
+        // 해당 날짜의 경기 필터링
+        const gamesOnDate = schedule.filter(game => game.day === formattedDate);
+
+        if (gamesOnDate.length === 0) {
+            alert("해당 날짜에 경기가 없습니다.");
+            return;
+        }
+
+        // 기존 select 제거
+        const existingSelect = document.getElementById("dynamicGameSelect");
+        if (existingSelect) existingSelect.remove();
+
+        // select 엘리먼트 생성
+        const select = document.createElement("select");
+        select.id = "dynamicGameSelect"; // id 추가
+        select.classList.add("form-select", "form-select-sm");
+        select.setAttribute("aria-label", "Small select example");
+
+        const defaultOption = document.createElement("option");
+        defaultOption.selected = true;
+        defaultOption.textContent = "경기 선택";
+        select.appendChild(defaultOption);
+
+        // 경기 옵션 추가 (점수 제거)
+        gamesOnDate.forEach((game, index) => {
+            const option = document.createElement("option");
+
+            // 점수 제거하고 팀명만 추출 (정규식 사용)
+            const gameContentRegex = /([가-힣a-zA-Z]+)\d*vs\d*([가-힣a-zA-Z]+)/;
+            const match = gameContentRegex.exec(game.gameContent);
+
+            if (match) {
+                option.value = index;
+                option.textContent = `${match[1]} vs ${match[2]}`;
+            } else {
+                option.value = index;
+                option.textContent = game.gameContent; // 기본 텍스트
+            }
+
+            select.appendChild(option);
+        });
+
+        // 선택 시 diary.html로 이동
+        select.addEventListener("change", () => {
+            const selectedIndex = select.value;
+            if (selectedIndex) {
+                const selectedGame = gamesOnDate[selectedIndex];
+                window.location.href = `diary.html?date=${date}&game=${encodeURIComponent(selectedGame.gameContent)}`;
+            }
+        });
+
+        // 동적으로 select 위치 설정
+        select.style.position = "absolute";
+        select.style.left = `${event.pageX}px`;
+        select.style.top = `${event.pageY}px`;
+        select.style.zIndex = "1000";
+
+        document.body.appendChild(select);
+
+        // select가 포커스를 잃으면 제거
+        select.addEventListener("blur", () => {
+            select.remove();
+        });
+
+        // select 표시 후 포커스
+        select.focus();
+    } catch (error) {
+        console.error("Error loading game data:", error);
+    }
+}


### PR DESCRIPTION
# 관련 이슈
#13 

# 구현 내용
### 캘린더 페이지
- [x] 날짜 클릭 시 schedule.json에서 로드
- [x]  해당 날짜의 경기 목록 중 일기를 작성할 경기 선택 
- [x] 일기 작성 페이지로 이동

### 일기 작성 페이지
- [x] 선택한 경기 데이터 schedule.json에서 로드
- [x] 날짜, 시간, 날씨(우천 취소 여부), 구장, 팀 정보, 스코어 파싱 후 출력
- [x] 경기가 없을 시 alert 메시지 출력